### PR TITLE
Auto-loot coins on SuperWoW

### DIFF
--- a/RollFor/RollFor.toc
+++ b/RollFor/RollFor.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: RollFor
 ## Author: Obszczymucha
-## Version: 4.1.2
+## Version: 4.1.3
 ## Notes: An automated item roller with soft ressing support via raidres.fly.dev.
 ## SavedVariables: RollForDb
 ## SavedVariablesPerCharacter: RollForCharDb

--- a/RollFor/main.lua
+++ b/RollFor/main.lua
@@ -246,7 +246,7 @@ local function create_components()
   M.master_loot_warning = m.MasterLootWarning.new( M.api, M.config, m.BossList.zones, M.player_info )
 
   -- TODO: Add type.
-  M.auto_loot = m.AutoLoot.new( M.loot_list, M.api, db( "auto_loot" ), M.config )
+  M.auto_loot = m.AutoLoot.new( M.loot_list, M.api, db( "auto_loot" ), M.config, M.player_info )
 
   -- TODO: Add type.
   M.new_group_event = m.NewGroupEvent.new( M.group_roster )

--- a/RollFor/src/AutoLoot.lua
+++ b/RollFor/src/AutoLoot.lua
@@ -25,7 +25,7 @@ local _G = getfenv( 0 )
 ---@param api table
 ---@param db table
 ---@param config Config
-function M.new( loot_list, api, db, config )
+function M.new( loot_list, api, db, config, player_info )
   db.items = db.items or {}
 
   local frame
@@ -41,6 +41,10 @@ function M.new( loot_list, api, db, config )
   end
 
   local function on_auto_loot()
+    if not player_info.is_master_looter() then
+      return
+    end
+
     local zone_name = api().GetRealZoneText()
     local item_ids = items[ zone_name ] or {}
     local threshold = m.api.GetLootThreshold()
@@ -48,6 +52,16 @@ function M.new( loot_list, api, db, config )
     for _, item in ipairs( loot_list.get_items() ) do
       local quality = item.quality or 0
       local slot = loot_list.get_slot( item.id )
+
+      -- Looting coins is hidden under a secure button and cannot be done
+      -- through vanilla API. If the user has the SuperWoW mod, we can call an
+      -- extra function instead.
+      if SUPERWOW_VERSION and item.type == item_utils.LootType.Coin then
+        api().LootSlot( slot, 1 )
+
+        local amount = string.gsub( string.gsub( item.amount_text, "\n", " " ), " $", "" )
+        info( string.format( "Auto-looting %s", grey(amount) ) )
+      end
 
       if item.id and slot then
         if quality < threshold or config.auto_loot() and item_ids[ item.id ] then


### PR DESCRIPTION
This is one approach to allow auto-looting coins when master looting.

I couldn't find a way to make the vanilla API loot them, neither `LootSlot()` nor calling `Click()` on a LootButton do anything. This PR relies instead on [the SuperWoW client mod](https://github.com/balakethelock/SuperWoW/wiki/Features) that adds a custom argument to allow you to actually loot the slot.

While client modifications may or may not be questionable, I think this is a simple enough QoL change that doesn't bring any extra baggage and is only activated if the user happens to have this mod already.

Tested on TurtleWoW