### PR TITLE
Add Shift click to Roll button to insert /rf command in chat

### DIFF
--- a/RollFor/RollFor.toc
+++ b/RollFor/RollFor.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: RollFor
 ## Author: Obszczymucha
-## Version: 4.1.4
+## Version: 4.1.5
 ## Notes: An automated item roller with soft ressing support via raidres.fly.dev.
 ## SavedVariables: RollForDb
 ## SavedVariablesPerCharacter: RollForCharDb

--- a/RollFor/src/RollController.lua
+++ b/RollFor/src/RollController.lua
@@ -380,8 +380,12 @@ function M.new(
   ---@param item_count number
   local function add_roll_button( buttons, strategy, item, item_count )
     table.insert( buttons, button( "Roll", function()
-      player_selection_frame.hide()
-      start( strategy, item, item_count, config.default_rolling_time_seconds() )
+      if m.is_shift_key_down() then
+        m.slash_command_in_chat( m.Types.RollSlashCommand.NormalRoll, item.link )
+      else
+        player_selection_frame.hide()
+        start( strategy, item, item_count, config.default_rolling_time_seconds() )
+      end
     end ) )
   end
 

--- a/RollFor/src/Types.lua
+++ b/RollFor/src/Types.lua
@@ -8,6 +8,13 @@ local M = {}
 ---@alias PlayerName string
 ---@alias ItemId number
 
+---@class RollSlashCommand
+---@field NormalRoll "/rf"
+---@field NoSoftResRoll "/arf"
+---@field RaidRoll "/rr"
+---@field InstaRaidRoll "/irr"
+
+---@type RollSlashCommand
 M.RollSlashCommand = {
   NormalRoll = "/rf",
   NoSoftResRoll = "/arf",

--- a/RollFor/src/modules.lua
+++ b/RollFor/src/modules.lua
@@ -742,4 +742,11 @@ function M.link_item_in_chat( item_link )
   end
 end
 
+---@param slash_command RollSlashCommand
+---@param item_link string
+function M.slash_command_in_chat( slash_command, item_link )
+  M.api.ChatFrameEditBox:Show()
+  M.api.ChatFrameEditBox:SetText( string.format( "%s %s ", slash_command, item_link ) )
+end
+
 return M


### PR DESCRIPTION
Small update to add shift-click to the Roll button to insert a /rf [item] command in chat.