### PR TITLE
Fix BoE indicator and realing it in the loot frame.

### DIFF
--- a/RollFor/RollFor.toc
+++ b/RollFor/RollFor.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: RollFor
 ## Author: Obszczymucha
-## Version: 4.2.1
+## Version: 4.2.2
 ## Notes: An automated item roller with soft ressing support via raidres.fly.dev.
 ## SavedVariables: RollForDb
 ## SavedVariablesPerCharacter: RollForCharDb

--- a/RollFor/src/GuiElements.lua
+++ b/RollFor/src/GuiElements.lua
@@ -351,6 +351,7 @@ function M.dropped_item( parent, text )
   local w = 22
   local h = 22
   local spacing = 6
+  local bind_spacing = 3
   local mouse_down = false
   local icon_zoom = 1
 
@@ -381,7 +382,17 @@ function M.dropped_item( parent, text )
     container.text:SetJustifyH( "LEFT" )
 
     local comment_width = container.comment:IsVisible() and container.comment:GetWidth() + 7 or 0
-    container:SetWidth( container.index:GetWidth() + container.icon:GetWidth() + spacing + container.bind:GetWidth() + spacing + container.text:GetWidth() + 7 + comment_width )
+    local total_width = container.index:GetWidth() +
+        container.icon:GetWidth() + spacing +
+        container.bind:GetWidth() + spacing +
+        container.text:GetWidth() + 7 +
+        comment_width
+
+    if item.bind then
+      total_width = total_width + bind_spacing
+    end
+
+    container:SetWidth( total_width )
     container:SetPoint( "LEFT", 0, 0 )
     container:SetPoint( "RIGHT", 0, 0 )
   end
@@ -443,7 +454,7 @@ function M.dropped_item( parent, text )
     if v.bind then
       container.bind.text:SetText( v.bind )
       container.bind:Show()
-      container.text:SetPoint( "LEFT", container.bind, "RIGHT", spacing, 0 )
+      container.text:SetPoint( "LEFT", container.bind, "RIGHT", spacing + bind_spacing, 0 )
     else
       container.bind:Hide()
       container.text:SetPoint( "LEFT", container.icon, "RIGHT", spacing, 0 )

--- a/RollFor/src/ItemUtils.lua
+++ b/RollFor/src/ItemUtils.lua
@@ -53,13 +53,15 @@ M.LootType = LootType
 ---@field BindOnEquip "BindOnEquip"
 ---@field Soulbound "Soulbound"
 ---@field Quest "Quest"
+---@field None "None"
 
 ---@type BT
 local BindType = {
   BindOnPickup = "BindOnPickup",
   BindOnEquip = "BindOnEquip",
   Soulbound = "Soulbound",
-  Quest = "Quest"
+  Quest = "Quest",
+  None = "None"
 }
 
 M.BindType = BindType
@@ -69,6 +71,7 @@ M.BindType = BindType
 ---| "BindOnEquip"
 ---| "Soulbound"
 ---| "Quest"
+---| "None"
 
 ---@alias ItemQuality
 ---| 0 -- Poor
@@ -125,7 +128,7 @@ M.BindType = BindType
 ---  quality: ItemQuality,
 ---  quantity: number,
 ---  texture: string,
----  bind: BindType?, ): DroppedItem
+---  bind: BindType ): DroppedItem
 
 ---@alias MakeSoftRessedDroppedItemFn fun(
 ---  item: DroppedItem,
@@ -140,8 +143,8 @@ M.BindType = BindType
 ---@field parse_link fun( item_link: string ): ItemLink? -- Sometimes we need to parse the link from the "[Item Name]x4." string.
 ---@field parse_all_links fun( item_links: string ): ItemLink[]
 ---@field get_tooltip_link fun( item_link: ItemLink ): TooltipItemLink
----@field bind_description fun( bind: BindType? ): string
----@field bind_abbrev fun( bind: BindType? ): string
+---@field bind_description fun( bind: BindType ): string?
+---@field bind_abbrev fun( bind: BindType ): string?
 ---@field make_item MakeItemFn
 ---@field make_dropped_item MakeDroppedItemFn
 ---@field make_softres_dropped_item MakeSoftRessedDroppedItemFn
@@ -192,29 +195,25 @@ function M.get_tooltip_link( item_link )
   return string.match( item_link, "|H(item:[^|]+)|h" )
 end
 
----@param bind BindType?
+---@param bind BindType
 ---@return string?
 function M.bind_description( bind )
   if bind == BindType.BindOnPickup or bind == BindType.Soulbound then
-    return red("Bind on Pickup")
+    return red( "Bind on Pickup" )
   elseif bind == BindType.BindOnEquip then
-    return green("Bind on Equip")
+    return green( "Bind on Equip" )
   elseif bind == BindType.Quest then
-    return red("Quest Item")
-  else
-    return nil
+    return red( "Quest Item" )
   end
 end
 
----@param bind BindType?
+---@param bind BindType
 ---@return string?
 function M.bind_abbrev( bind )
   if bind == BindType.BindOnPickup or bind == BindType.Soulbound or bind == BindType.Quest then
-    return red("BoP")
+    return red( "BoP" )
   elseif bind == BindType.BindOnEquip then
-    return green("BoE")
-  else
-    return nil
+    return green( "BoE" )
   end
 end
 
@@ -253,7 +252,7 @@ function M.make_dropped_item( id, name, link, tooltip_link, quality, quantity, t
     quality = quality,
     quantity = quantity,
     texture = texture,
-    bind = bind,
+    bind = bind or BindType.None,
     type = LootType.DroppedItem
   }
 end

--- a/RollFor/src/TooltipReader.lua
+++ b/RollFor/src/TooltipReader.lua
@@ -3,10 +3,10 @@ local m = RollFor
 
 if m.TooltipReader then return end
 
-local item_utils = m.ItemUtils
 
 local M = {}
 local _G = getfenv( 0 )
+local BindType = m.ItemUtils.BindType
 
 local function create_tooltip_frame()
   local frame = m.api.CreateFrame( "GameTooltip", "RollForTooltipFrame", nil, "GameTooltipTemplate" )
@@ -16,58 +16,57 @@ local function create_tooltip_frame()
 end
 
 ---@class TooltipReader
----@field get_slot_bind_type fun( number? ): BindType?
+---@field get_slot_bind_type fun( slot: number ): BindType
 
 ---@param api table
 function M.new( api )
-    local m_frame
+  local m_frame
 
-    local function ensure_frame()
-        if m_frame then return end
-        m_frame = create_tooltip_frame()
+  local function ensure_frame()
+    if m_frame then return end
+    m_frame = create_tooltip_frame()
+  end
+
+  ---@param slot number?
+  local function set_loot_slot( slot )
+    ensure_frame()
+
+    m_frame:ClearLines()
+    m_frame:SetLootItem( slot )
+  end
+
+  ---@return BindType
+  local function get_item_type_from_tooltip()
+    local num_lines = m_frame:NumLines()
+
+    if num_lines < 2 then
+      return BindType.None
     end
 
-    ---@param slot number?
-    local function set_loot_slot( slot )
-        ensure_frame()
+    local line = _G[ "RollForTooltipFrameTextLeft2" ]:GetText()
 
-        m_frame:ClearLines()
-        m_frame:SetLootItem( slot )
+    if line == api.ITEM_BIND_ON_PICKUP or line == api.ITEM_SOULBOUND then
+      return BindType.BindOnPickup
+    elseif line == api.ITEM_BIND_ON_EQUIP then
+      return BindType.BindOnEquip
+    elseif line == api.ITEM_BIND_QUEST then
+      return BindType.Quest
+    else
+      return BindType.None
     end
+  end
 
-    ---@return BindType?
-    local function get_item_type_from_tooltip()
-        if m_frame:NumLines() < 1 then
-            -- Probably the slot is invalid
-            return
-        elseif m_frame:NumLines() < 2 then
-            -- Items without a specification are assumed to be BoE
-            return item_utils.BindType.BindOnEquip
-        end
+  local function get_slot_bind_type( slot )
+    set_loot_slot( slot )
 
-        local line = _G["RollForTooltipFrameTextLeft2"]:GetText()
+    return get_item_type_from_tooltip()
+  end
 
-        if line == api.ITEM_BIND_ON_PICKUP or line == api.ITEM_SOULBOUND then
-            return item_utils.BindType.BindOnPickup
-        elseif line == api.ITEM_BIND_QUEST then
-            return item_utils.BindType.Quest
-        else
-            return item_utils.BindType.BindOnEquip
-        end
-    end
-
-    local function get_slot_bind_type( slot )
-        set_loot_slot( slot )
-
-        return get_item_type_from_tooltip()
-    end
-
-    ---@type TooltipReader
-    return {
-        get_slot_bind_type = get_slot_bind_type
-    }
+  ---@type TooltipReader
+  return {
+    get_slot_bind_type = get_slot_bind_type
+  }
 end
 
 m.TooltipReader = M
 return M
-

--- a/test/IntegrationTestBuilder.lua
+++ b/test/IntegrationTestBuilder.lua
@@ -13,6 +13,7 @@ local c, r, pm = u.console_message, u.raid_message, u.party_message ---@diagnost
 local cr, rw = u.console_and_raid_message, u.raid_warning ---@diagnostic disable-line: unused-local
 local C, RT, RS = T.PlayerClass, T.RollType, T.RollingStrategy ---@diagnostic disable-line: unused-local
 local make_player = T.make_player
+local BindType = IU.BindType
 
 u.mock_wow_api()
 
@@ -98,7 +99,7 @@ end
 function M.i( name, id, sr_players, hard_ressed, quality, bind_type )
   local l = u.item_link( name, id )
   local tooltip_link = IU.get_tooltip_link( l )
-  local item = IU.make_dropped_item( id or 123, name, l, tooltip_link, quality or 4, nil, nil, bind_type )
+  local item = IU.make_dropped_item( id or 123, name, l, tooltip_link, quality or 4, nil, nil, bind_type or BindType.None )
 
   if hard_ressed then
     return IU.make_hardres_dropped_item( item )

--- a/test/mainspec_rolls_test.lua
+++ b/test/mainspec_rolls_test.lua
@@ -2,6 +2,7 @@ package.path = "./?.lua;" .. package.path .. ";../?.lua;../RollFor/?.lua;../Roll
 
 local u = require( "test/utils" )
 local lu, eq = u.luaunit( "assertEquals" )
+require( "src/modules" )
 local player, leader = u.player, u.raid_leader
 local is_in_raid = u.is_in_raid
 local c, r = u.console_message, u.raid_message
@@ -9,7 +10,7 @@ local cr, rw = u.console_and_raid_message, u.raid_warning
 local rolling_finished, rolling_not_in_progress = u.rolling_finished, u.rolling_not_in_progress
 local roll_for, roll, finish_rolling = u.roll_for, u.roll, u.finish_rolling
 local repeating_tick = u.repeating_tick
-local m, t, i = require( "src/modules" ), require( "src/Types" ), require( "src/ItemUtils" )
+local t, i = require( "src/Types" ), require( "src/ItemUtils" )
 local make_item_candidate, make_dropped_item = t.make_item_candidate, i.make_dropped_item
 local C = t.PlayerClass
 


### PR DESCRIPTION
The BoE indicator was incorrectly showing up on the grey and white items, as well as on green items that weren't BoE, such as Shadowgem.
I reformatted the code, fixed the type annotations and realigned the bind indicator (it was glued to the item text).