### PR TITLE
New option to auto announce class on rolls

### DIFF
--- a/RollFor/RollFor-BCC.toc
+++ b/RollFor/RollFor-BCC.toc
@@ -1,7 +1,7 @@
 ## Interface: 20502
 ## Title: RollFor
 ## Author: Obszczymucha
-## Version: 4.6.5
+## Version: 4.7.1
 ## Notes: An automated item roller with soft ressing support via softres.it.
 ## SavedVariables: RollForDb
 ## SavedVariablesPerCharacter: RollForCharDb

--- a/RollFor/RollFor.toc
+++ b/RollFor/RollFor.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: RollFor
 ## Author: Obszczymucha
-## Version: 4.6.5
+## Version: 4.7.1
 ## Notes: An automated item roller with soft ressing support via raidres.fly.dev.
 ## SavedVariables: RollForDb
 ## SavedVariablesPerCharacter: RollForCharDb

--- a/RollFor/src/Config.lua
+++ b/RollFor/src/Config.lua
@@ -27,6 +27,7 @@ function M.new( db, event_bus )
     [ "superwow_auto_loot_coins" ] = { cmd = "superwow-auto-loot-coins", display = "Auto-loot coins with SuperWoW", help = "toggle auto-loot coins with SuperWoW" },
     [ "auto_loot_messages" ] = { cmd = "auto-loot-messages", display = "Auto-loot messages", help = "toggle auto-loot messages" },
     [ "auto_loot_announce" ] = { cmd = "auto-loot-announce", display = "Announce auto-looted items", help = "toggle announcements of auto-loot items" },
+    [ "auto_class_announce" ] = { cmd = "auto-class-announce", display = "Announce class restriction on items", help = "toggle announcing of class restriction on items" },
     [ "show_ml_warning" ] = { cmd = "ml", display = "Master loot warning", help = "toggle master loot warning" },
     [ "auto_raid_roll" ] = { cmd = "auto-rr", display = "Auto raid-roll", help = "toggle auto raid-roll" },
     [ "auto_group_loot" ] = { cmd = "auto-group-loot", display = "Auto group loot", help = "toggle auto group loot" },
@@ -409,6 +410,7 @@ function M.new( db, event_bus )
     default_rolling_time_seconds = get( "default_rolling_time_seconds" ),
     master_loot_frame_rows = get( "master_loot_frame_rows" ),
     configure_master_loot_frame_rows = configure_master_loot_frame_rows,
+    auto_class_announce = get( "auto_class_announce" )
   }
 
   for toggle_key, _ in pairs( toggles ) do

--- a/RollFor/src/ItemUtils.lua
+++ b/RollFor/src/ItemUtils.lua
@@ -90,6 +90,7 @@ M.BindType = BindType
 ---@field link ItemLink
 ---@field quality ItemQuality?
 ---@field texture string?
+---@field classes table<number, PlayerClass>?
 ---@field type "Item"
 
 ---@class DroppedItem : Item
@@ -127,7 +128,8 @@ M.BindType = BindType
 ---  quality: ItemQuality,
 ---  quantity: number,
 ---  texture: string,
----  bind: BindType ): DroppedItem
+---  bind: BindType,
+---  classes: table<number, PlayerClass>|nil ): DroppedItem
 
 ---@alias MakeSoftRessedDroppedItemFn fun(
 ---  item: DroppedItem,
@@ -228,8 +230,9 @@ end
 ---@param quantity number?
 ---@param texture string?
 ---@param bind BindType?
+---@param classes table<number, PlayerClass>?
 ---@return DroppedItem
-function M.make_dropped_item( id, name, link, tooltip_link, quality, quantity, texture, bind )
+function M.make_dropped_item( id, name, link, tooltip_link, quality, quantity, texture, bind, classes )
   return {
     id = id,
     name = name,
@@ -239,6 +242,7 @@ function M.make_dropped_item( id, name, link, tooltip_link, quality, quantity, t
     quantity = quantity,
     texture = texture,
     bind = bind or BindType.None,
+    classes = classes,
     type = LootType.DroppedItem
   }
 end

--- a/RollFor/src/LootList.lua
+++ b/RollFor/src/LootList.lua
@@ -66,6 +66,7 @@ function M.new( loot_facade, item_utils, tooltip_reader, dummy_items_fn )
         local item_name = link and item_utils.get_item_name( link )
         local tooltip_link = link and item_utils.get_tooltip_link( link )
         local bind_type = tooltip_reader.get_slot_bind_type( slot )
+        local classes = tooltip_reader.get_slot_classes( slot )
 
         if item_id and item_name then
           add_item( slot,
@@ -77,7 +78,8 @@ function M.new( loot_facade, item_utils, tooltip_reader, dummy_items_fn )
               info and info.quality,
               info and info.quantity,
               info and info.texture,
-              bind_type
+              bind_type,
+              classes
             ), item_count )
 
           item_count = item_count + 1

--- a/RollFor/src/ModernLootFrameSkin.lua
+++ b/RollFor/src/ModernLootFrameSkin.lua
@@ -35,6 +35,7 @@ function M.new( frame_builder )
     container.index:SetHeight( h )
     container.icon = gui.create_icon_in_container( "Button", container, w, h, icon_zoom )
     container.icon:SetPoint( "LEFT", container.index, "RIGHT", 2, 0 )
+    container.icon:EnableMouse( false )
     container.quantity = gui.create_text_in_container( "Frame", container.icon, 20, "CENTER", nil, "text", "NumberFontNormalSmall" )
     container.quantity:SetPoint( "BOTTOMRIGHT", 1, -2 )
     container.quantity:SetHeight( 16 )
@@ -153,7 +154,6 @@ function M.new( frame_builder )
       end
 
       container:SetScript( "OnClick", v.is_enabled and not v.is_selected and v.click_fn or modifier_fn )
-      container.icon:SetScript( "OnClick", v.is_enabled and not v.is_selected and v.click_fn or modifier_fn )
       container.comment:SetScript( "OnClick", v.is_enabled and not v.is_selected and v.click_fn or modifier_fn )
 
       if m.vanilla then
@@ -230,9 +230,6 @@ function M.new( frame_builder )
       not_hovered_color()
     end )
 
-    container.icon:SetScript( "OnEnter", on_enter )
-    container.icon:SetScript( "OnLeave", on_leave )
-
     container:SetScript( "OnEnter", on_enter )
     container:SetScript( "OnLeave", on_leave )
 
@@ -254,8 +251,6 @@ function M.new( frame_builder )
 
     container:SetScript( "OnMouseUp", on_mouse_up )
     container:SetScript( "OnMouseDown", on_mouse_down )
-    container.icon:SetScript( "OnMouseUp", on_mouse_up )
-    container.icon:SetScript( "OnMouseDown", on_mouse_down )
 
     container:SetScript( "OnShow", function()
       mouse_down = false

--- a/RollFor/src/NonSoftResRollingLogic.lua
+++ b/RollFor/src/NonSoftResRollingLogic.lua
@@ -218,6 +218,12 @@ function M.new(
     local info_str = info and info ~= "" and string.format( " %s", info ) or roll_info
     local x_rolls_win = item_count > 1 and string.format( ". %d top rolls win.", item_count ) or ""
 
+    if item.classes and config.auto_class_announce() then
+      local class_str = table.concat( item.classes, "s, " )
+      class_str = string.gsub( class_str, ", (%S+)$", " and %1" )
+      info_str = string.format( " %ss", class_str )
+    end
+
     chat.announce( string.format( "Roll for %s%s:%s%s", count_str, item.link, info_str, x_rolls_win ), true )
     accept_rolls()
   end

--- a/RollFor/src/TooltipReader.lua
+++ b/RollFor/src/TooltipReader.lua
@@ -17,6 +17,7 @@ end
 
 ---@class TooltipReader
 ---@field get_slot_bind_type fun( slot: number ): BindType
+---@field get_slot_classes fun( slot: number ): table<number, PlayerClass>|nil
 
 ---@param api table
 function M.new( api )
@@ -56,15 +57,42 @@ function M.new( api )
     end
   end
 
+  ---@return table<number, PlayerClass>|nil
+  local function get_item_classes_from_tooltip()
+    local num_lines = m_frame:NumLines()
+
+    for i = 1, num_lines do
+      local line = _G[ "RollForTooltipFrameTextLeft" .. i ]:GetText()
+
+      for classes in string.gmatch( line, "Classes: (.+)" ) do
+        local result = {}
+
+        for class in string.gmatch( classes, "([^, ]+)" ) do
+          table.insert( result, class )
+        end
+
+        return result
+      end
+    end
+    return nil
+  end
+
   local function get_slot_bind_type( slot )
     set_loot_slot( slot )
 
     return get_item_type_from_tooltip()
   end
 
+  local function get_slot_classes( slot )
+    set_loot_slot( slot )
+
+    return get_item_classes_from_tooltip()
+  end
+
   ---@type TooltipReader
   return {
-    get_slot_bind_type = get_slot_bind_type
+    get_slot_bind_type = get_slot_bind_type,
+    get_slot_classes = get_slot_classes
   }
 end
 

--- a/test/IntegrationTestBuilder.lua
+++ b/test/IntegrationTestBuilder.lua
@@ -66,7 +66,8 @@ function M.mock_config( configuration )
         str = "/roll"
       }
     end,
-    classic_look = function() return false end
+    classic_look = function() return false end,
+    auto_class_announce = function() return true end
   }
 end
 
@@ -96,11 +97,12 @@ end
 ---@param hard_ressed boolean?
 ---@param quality number?
 ---@param bind_type BindType?
+---@param classes table<number, PlayerClass>?
 ---@return MasterLootDistributableItem
-function M.i( name, id, sr_players, hard_ressed, quality, bind_type )
+function M.i( name, id, sr_players, hard_ressed, quality, bind_type, classes )
   local l = u.item_link( name, id )
   local tooltip_link = IU.get_tooltip_link( l )
-  local item = IU.make_dropped_item( id or 123, name, l, tooltip_link, quality or 4, nil, nil, bind_type or BindType.None )
+  local item = IU.make_dropped_item( id or 123, name, l, tooltip_link, quality or 4, nil, nil, bind_type or BindType.None, classes )
 
   if hard_ressed then
     return IU.make_hardres_dropped_item( item )


### PR DESCRIPTION
Added a new option /rf config auto-class-announce
It will replace default roll message with a list of classes when rolling on items with class restrictions. Everyone is still allowed to roll, but maybe limiting who can roll would be a good idea?